### PR TITLE
fix: Set standard weight and style for Alegreya Sans font

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ brand:
     fonts:
       - family: Alegreya Sans
         source: google
+        weight: [400, 700]
+        style: [normal, italic]
     base:
       family: "Alegreya Sans"
       size: 12pt

--- a/template.qmd
+++ b/template.qmd
@@ -43,6 +43,8 @@ brand:
     fonts:
       - family: Alegreya Sans
         source: google
+        weight: [400, 700]
+        style: [normal, italic]
     base:
       family: "Alegreya Sans"
       size: 12pt


### PR DESCRIPTION
Define standard font weights and styles for the Alegreya Sans font in both the README and template files.