### PR TITLE
fix: font handling in typst template

### DIFF
--- a/_extensions/invoice/_extension.yml
+++ b/_extensions/invoice/_extension.yml
@@ -1,7 +1,7 @@
 title: Invoice
 author: Mickaël Canouil
 version: 1.2.4
-quarto-required: ">=1.6.39"
+quarto-required: ">=1.7.30"
 contributes:
   formats:
     typst:

--- a/_extensions/invoice/typst-show.typ
+++ b/_extensions/invoice/typst-show.typ
@@ -69,7 +69,7 @@ $endif$
 $if(mainfont)$
   font: ("$mainfont$",),
 $elseif(brand.typography.base.family)$
-  font: ("$brand.typography.base.family$",),
+  font: $brand.typography.base.family$,
 $endif$
 $if(fontsize)$
   fontsize: $fontsize$,
@@ -78,7 +78,7 @@ $elseif(brand.typography.base.size)$
 $endif$
 $if(title)$
 $if(brand.typography.headings.family)$
-  heading-family: ("$brand.typography.headings.family$",),
+  heading-family: $brand.typography.headings.family$,
 $endif$
 $if(brand.typography.headings.weight)$
   heading-weight: $brand.typography.headings.weight$,

--- a/_extensions/invoice/typst-template.typ
+++ b/_extensions/invoice/typst-template.typ
@@ -43,6 +43,7 @@
   heading-family: none,
   heading-weight: "bold",
   heading-style: "normal",
+  heading-decoration: none,
   heading-color: black,
   heading-line-height: 0.65em,
   fontsize: 12pt,


### PR DESCRIPTION
Update the typst template to support a list of fonts without parentheses. Adjust the font handling method in the template to ensure compatibility with Quarto version 1.7.30. 
Fixes #16.
The required Quarto version has also been updated in the extension configuration.